### PR TITLE
Create `MainLoop`, `WindowLoop` and a basic example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "ottr"
 description = "A highly parallel game engine"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/otterengine/ottr"
 readme = "README.md"
 categories = ["game-engines", "graphics", "rendering"]
 keywords = ["game", "engine", "graphics", "gamedev", "otter"]
@@ -10,5 +8,18 @@ documentation = "https://docs.rs/ottr"
 exclude = [".github", ".husky", "node_modules", "assets", "*.json"]
 version = "0.1.0"
 edition = "2021"
+license.workspace = true
+repository.workspace = true
+
+[workspace]
+members = ["crates/*"]
+
+package.license = "MIT OR Apache-2.0"
+package.repository = "https://github.com/otterengine/ottr"
+
+[features]
+default = ["std"]
+std = ["ottr_main/std"]
 
 [dependencies]
+ottr_main = { path = "crates/ottr_main", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ package.license = "MIT OR Apache-2.0"
 package.repository = "https://github.com/otterengine/ottr"
 
 [features]
-default = ["std"]
+default = ["std", "ottr_window"]
 std = ["ottr_main/std"]
 
 [dependencies]
 ottr_main = { path = "crates/ottr_main", default-features = false }
+ottr_window = { path = "crates/ottr_window", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ std = ["ottr_main/std"]
 [dependencies]
 ottr_main = { path = "crates/ottr_main", default-features = false }
 ottr_window = { path = "crates/ottr_window", optional = true }
+
+[dev-dependencies]
+tokio = { version = "1.42.0", features = ["full"] }

--- a/crates/ottr_main/Cargo.toml
+++ b/crates/ottr_main/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ottr_main"
+description = "Utilities for defining the main loop of an Otter application"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+repository.workspace = true
+
+[features]
+default = ["std"]
+std = []
+
+[dependencies]

--- a/crates/ottr_main/src/lib.rs
+++ b/crates/ottr_main/src/lib.rs
@@ -1,0 +1,37 @@
+//! # ottr_main
+//!
+//! Provides utilities for defining a [`MainLoop`] for an Otter application.
+//!
+
+use core::future::Future;
+
+#[cfg(feature = "std")]
+use std::process::{ExitCode, Termination};
+
+/// `use ottr_main::prelude::*;` to import the most common types, traits and functions.
+pub mod prelude {
+    pub use crate::{MainLoop, MainLoopExit};
+}
+
+/// The value [`MainLoop::run`] returns to indicate success or failure.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct MainLoopExit(pub u8);
+
+impl<T: Into<u8>> From<T> for MainLoopExit {
+    fn from(value: T) -> Self {
+        Self(value.into())
+    }
+}
+
+#[cfg(feature = "std")]
+impl Termination for MainLoopExit {
+    fn report(self) -> ExitCode {
+        ExitCode::from(self.0)
+    }
+}
+
+/// An interface used to run an Otter application.
+pub trait MainLoop {
+    /// Run the main loop.
+    fn run(self) -> impl Future<Output = MainLoopExit>;
+}

--- a/crates/ottr_window/Cargo.toml
+++ b/crates/ottr_window/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ottr_window"
+description = "A windowing library for Otter"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+winit = "0.30.8"
+flume = "0.11.1"
+futures = "0.3.31"
+
+ottr_main = { path = "../ottr_main" }

--- a/crates/ottr_window/src/lib.rs
+++ b/crates/ottr_window/src/lib.rs
@@ -1,0 +1,93 @@
+//! # ottr_window
+//!
+//! Otter's windowing system. Most users will probably use
+//! the [`WindowLoop`] type, which implements
+//! [`MainLoop`].
+//!
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+
+use ottr_main::{MainLoop, MainLoopExit};
+use winit::{
+    application::ApplicationHandler,
+    event::WindowEvent,
+    event_loop::{ActiveEventLoop, EventLoop},
+    window::{Window, WindowAttributes, WindowId},
+};
+
+/// `use ottr_window::prelude::*;` to import the most common types, traits and functions.
+pub mod prelude {
+    pub use crate::WindowLoop;
+}
+
+/// An implementation of [`MainLoop`] for [`winit`].
+///
+/// This will create a window whenever [`MainLoop::run`] is called,
+/// and dispatch all events it produces.
+#[derive(Debug)]
+pub struct WindowLoop {
+    event_loop: EventLoop<()>,
+}
+
+impl WindowLoop {
+    pub fn new() -> Self {
+        let event_loop = EventLoop::new().expect("failed to create event loop");
+
+        WindowLoop { event_loop }
+    }
+}
+
+impl MainLoop for WindowLoop {
+    async fn run(self) -> MainLoopExit {
+        let Self { event_loop } = self;
+
+        let mut app = App::new();
+
+        if event_loop.run_app(&mut app).is_err() {
+            MainLoopExit(1)
+        } else {
+            MainLoopExit(0)
+        }
+    }
+}
+
+struct App {
+    window: Option<Arc<Window>>,
+}
+
+impl App {
+    fn new() -> Self {
+        Self { window: None }
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.window.is_some() {
+            return;
+        }
+
+        self.window = Some(
+            event_loop
+                .create_window(WindowAttributes::default())
+                .expect("failed to create window")
+                .into(),
+        );
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        _window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        match event {
+            WindowEvent::CloseRequested => {
+                event_loop.exit();
+            }
+            _ => {}
+        }
+    }
+}

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,0 +1,10 @@
+//! This example shows how to use `ottr_window` to create a window.
+
+use ottr::prelude::*;
+
+#[tokio::main]
+async fn main() -> MainLoopExit {
+    let loop_ = WindowLoop::new();
+
+    loop_.run().await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,7 @@
 /// `use ottr::prelude::*;` to import the most common types, traits and functions.
 pub mod prelude {
     pub use ottr_main::prelude::*;
+
+    #[cfg(feature = "ottr_window")]
+    pub use ottr_window::prelude::*;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,6 @@
+#![doc = include_str!("../README.md")]
 
+/// `use ottr::prelude::*;` to import the most common types, traits and functions.
+pub mod prelude {
+    pub use ottr_main::prelude::*;
+}


### PR DESCRIPTION
# Objective
Create an abstraction for how to run an app.
# Solution
Create the `MainLoop` trait, and a first implementation with `WindowLoop`.
# Other Notes
Added docs in the form of a basic example.
Moved around some stuff in `Cargo.toml` and `lib.rs` for the `cargo` workspace.